### PR TITLE
Minor error fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -391,9 +391,9 @@
 			}
 		},
 		"node_modules/path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"node_modules/picomatch": {
@@ -959,9 +959,9 @@
 			"integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"picomatch": {

--- a/src/routes/stripe/checkout-session.ts
+++ b/src/routes/stripe/checkout-session.ts
@@ -5,11 +5,12 @@ export async function post(req: Request<any, { priceId: string }>): Promise<Resp
 	if (typeof req.body.priceId !== 'string') {
 		return {
 			status: 400,
-			body: {
+			headers: {},
+			body: JSON.stringify({
 				error: {
 					message: 'priceId is required'
 				}
-			}
+			})
 		};
 	}
 
@@ -30,16 +31,18 @@ export async function post(req: Request<any, { priceId: string }>): Promise<Resp
 		});
 		return {
 			status: 200,
-			body: {
+			headers: {},
+			body: JSON.stringify({
 				sessionId: session.id
-			}
+			})
 		};
 	} catch (err) {
 		return {
 			status: 500,
-			body: {
+			headers: {},
+			body: JSON.stringify({
 				error: err
-			}
+			})
 		};
 	}
 }

--- a/src/routes/stripe/webhook.ts
+++ b/src/routes/stripe/webhook.ts
@@ -16,9 +16,10 @@ export async function post(req: Request<any, { data: any; type: any }>): Promise
 		} catch (err) {
 			return {
 				status: 500,
-				body: {
+				headers: {},
+				body: JSON.stringify({
 					error: err
-				}
+				})
 			};
 		}
 	} else {
@@ -50,8 +51,9 @@ export async function post(req: Request<any, { data: any; type: any }>): Promise
 
 	return {
 		status: 200,
-		body: {
+		headers: {},
+		body: JSON.stringify({
 			message: 'Success'
-		}
+		})
 	};
 }


### PR DESCRIPTION
While the project builds and runs normally when cloned, I got some small TS errors when looking at some files.

**Warning: Package Vulnerability** c68109660b53a29280a770ffbca486b781fb84f1
Solved with `$: npm audit fix` as a fix for the 1 vulnerability was available.
Likely unimpactful change but annoying warning removed nonetheless!
________________________________________________________________________________________ 

**Error 1: Type '{ error: any; }' is not assignable to type 'StrictBody'** ccf61efb233b62cfbd714830b45a4b4824886ea4
Solved by adding `JSON.stringify()` around the 'body' content.
________________________________________________________________________________________ 

**Error 2: Property 'headers' is required in type 'ServerResponse'** ccf61efb233b62cfbd714830b45a4b4824886ea4
Solved by adding `headers: {}` to each of the ServerResponses. 

________________________________________________________________________________________ 

Additionally, I've had some minor issues using process.env["secret-key-here"] at the moment in SvelteKit.
May have to watch and see if it becomes an issue later when initializing Stripe with the Secret Key. 
For now, it seems to work fine.