### PR TITLE
Improve Stripe webhook robustness

### DIFF
--- a/src/routes/stripe/webhook.ts
+++ b/src/routes/stripe/webhook.ts
@@ -8,9 +8,15 @@ export async function post(req: Request<any, { data: any; type: any }>): Promise
 	let eventType;
 	if (WEBHOOK_SECRET) {
 		let event;
+
+		// SvelteKit may sometimes modify the incoming request body
+		// However, Stripe requires the exact body it sends to construct an Event
+		// To avoid unintended SvelteKit modifications, we can use this workaround:
+		const payload = Buffer.from(req.rawBody);
+
 		const signature = req.headers['stripe-signature'];
 		try {
-			event = stripe.webhooks.constructEvent(req.rawBody as string, signature, WEBHOOK_SECRET);
+			event = stripe.webhooks.constructEvent(payload, signature, WEBHOOK_SECRET);
 			data = event.data;
 			eventType = event.type;
 		} catch (err) {


### PR DESCRIPTION
**Stripe Webhook Handling Robustness** 3428fd4c9a54ab2a3d140db7c23d5225e6697ece

For devs studying this repo to, f.ex., implement Stripe in a larger project, it is very beneficial to add some extra robustness to the webhook handling.

SvelteKit may in many cases automatically modify incoming requests through its hook handling. 
Stripe requires the constructEvent payload to be exactly the same as the one they sent in the incoming requests.
Therefore, we add in a little workaround to ensure the payload is exact and original.

This addition has the added benefit of removing stricter TypeScript errors due to type ambiguity in the constructEvent function, which was a problem on my end for a while (that is, req.rawBody type ambiguity).

To ensure the signature is correct, one may also modify the event initialization to:
`event = stripe.webhooks.constructEvent(payload, signature?.toString(), WEBHOOK_SECRET);`

Source:
- [StackOverflow -  Getting the raw body of a request to a SvelteKit endpoint](https://stackoverflow.com/questions/66913326/getting-the-raw-body-of-a-request-to-a-sveltekit-endpoint)